### PR TITLE
Do not send EventEmitter2 newListener events to the client process

### DIFF
--- a/lib/eventcom.js
+++ b/lib/eventcom.js
@@ -39,8 +39,9 @@ var EVENT_OPTIONS = {
 var EventCom = module.exports = function(options) {
   // Setup list of event names that are used by this class and can 
   // therefore not be emitted to the other side!!! (to prevent circular emits)
-  this.localEvents = ['error', 'stdout', 'stderr', 'warn', 'exit', 'close', 'start', 'restart', 'stop', 'rpcready', 
-                      'rpcexit', 'disconnect', 'disconnected']; 
+  this.localEvents = ['error', 'stdout', 'stderr', 'warn', 'exit', 'close',
+                      'start', 'restart', 'stop', 'rpcready', 'rpcexit',
+                      'disconnect', 'disconnected', 'newListener'];
 
   // rpc event session is not started yet
   this.started = false;
@@ -87,8 +88,10 @@ EventCom.prototype.emit = function emitHandler(event) {
     if (this.localEvents.indexOf(event) === -1) {
       this.rpcSession.remote.emit.apply(null, arguments);
     } else {
-      this.localEmit('error', 'Received forbidden event!', arguments);
-      return;
+      if (event !== 'newListener') {
+        this.localEmit('error', 'Received forbidden event!', arguments);
+        return;
+      }
     }
   }
   // also send to local instance


### PR DESCRIPTION
While using intercom over a long period of time, I noticed that it was slowly leaking some events/callbacks in the underlying dnode-protocol library.

It looks like eventemitter's 'newListener' event is being sent to the remote process, and because one of the arguments to that event is a function, it's putting it into a callback cache and waiting for a response.  Because the child will not reply to the newListener event, the callbacks are leaked.
